### PR TITLE
Prompt user for Private Passphrase on Wallet Open.

### DIFF
--- a/app/components/views/GetStartedPage/OpenWallet/DecryptForm.js
+++ b/app/components/views/GetStartedPage/OpenWallet/DecryptForm.js
@@ -8,6 +8,10 @@ const messages = defineMessages({
   publicPassphrasePlaceholder: {
     id: "getStarted.decrypt.publicPassphrasePlaceholder",
     defaultMessage: "Public Passphrase"
+  },
+  privatePassphrasePlaceholder: {
+    id: "getStarted.decrypt.privatePassphrasePlaceholder",
+    defaultMessage: "Private Passphrase"
   }
 });
 
@@ -27,19 +31,23 @@ const OpenWalletDecryptFormHeader = ({
 );
 
 const OpenWalletDecryptFormBodyBase = ({
-  isInputRequest,
+  isOpenWalletPrivateInputRequest,
+  isOpenWalletPublicInputRequest,
   publicPassPhrase,
+  privatePassPhrase,
   hasAttemptedOpen,
   intl,
+  onSetPrivatePassPhrase,
   onSetPublicPassPhrase,
   onOpenWallet,
   onKeyDown
-}) => (
-  isInputRequest ? (
+}) => {
+
+  const publicInputRequest = (
     <div className="get-started-view">
       <div className="get-started-form-ct">
         <div className="get-started-content-instructions">
-          <T id="getStarted.decrypt.info" m="This wallet is encrypted, please enter the public passphrase to decrypt it." />
+          <T id="getStarted.decrypt.info.public" m="This wallet is encrypted, please enter the public passphrase to decrypt it." />
         </div>
         <div className="get-started-field-ct">
           <div className="get-started-label">
@@ -72,8 +80,57 @@ const OpenWalletDecryptFormBodyBase = ({
         </div>
       </div>
     </div>
-  ) : null
-);
+  );
+
+  const privateInputRequest = (
+    <div className="get-started-view">
+      <div className="get-started-form-ct">
+        <div className="get-started-content-instructions">
+          <T id="getStarted.decrypt.info.private" m="Please enter the private passphrase to decrypt it." />
+        </div>
+        <div className="get-started-field-ct">
+          <div className="get-started-label">
+            <T id="getStarted.decrypt.label" m="Decrypt Wallet" />
+            :</div>
+          <div className="get-started-field">
+            <form className="get-started-input-form">
+              <PasswordInput
+                autoFocus
+                className="get-started-input-private-password"
+                placeholder={intl.formatMessage(messages.privatePassphrasePlaceholder)}
+                value={privatePassPhrase}
+                onChange={(e) => onSetPrivatePassPhrase(e.target.value)}
+                onKeyDown={onKeyDown}/>
+            </form>
+          </div>
+          {(hasAttemptedOpen && !privatePassPhrase) ? (
+            <div className="get-started-priv-pass-error">
+              <T id="getStarted.decrypt.errors.noPrivatePassphrase" m="*Please enter your private passphrase" />
+            </div>
+          ) : null}
+          <div className="get-started-field-ct">
+            <div className="get-started-label"></div>
+            <div className="get-started-field">
+              <KeyBlueButton onClick={onOpenWallet}>
+                <T id="getStarted.decrypt.openWalletBtn" m="Open Wallet" />
+              </KeyBlueButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  let view = null;
+
+  if (isOpenWalletPrivateInputRequest) {
+    view = privateInputRequest;
+  } else if (isOpenWalletPublicInputRequest) {
+    view = publicInputRequest;
+  }
+
+  return view;
+};
 const OpenWalletDecryptFormBody = injectIntl(OpenWalletDecryptFormBodyBase);
 
 export { OpenWalletDecryptFormHeader, OpenWalletDecryptFormBody };

--- a/app/components/views/GetStartedPage/OpenWallet/index.js
+++ b/app/components/views/GetStartedPage/OpenWallet/index.js
@@ -46,16 +46,18 @@ class OpenWalletBody extends React.Component {
   getInitialState() {
     return {
       publicPassPhrase: "",
+      privatePassPhrase: "",
       hasAttemptedOpen: false
     };
   }
 
   render() {
-    const { publicPassPhrase, hasAttemptedOpen, onKeyDown } = this.state;
+    const { publicPassPhrase, privatePassPhrase, hasAttemptedOpen, onKeyDown } = this.state;
     const { hasExistingWallet } = this.props;
     const {
       onSetPublicPassPhrase,
-      onOpenWallet
+      onSetPrivatePassPhrase,
+      onOpenWallet,
     } = this;
 
     return hasExistingWallet ? (
@@ -63,8 +65,10 @@ class OpenWalletBody extends React.Component {
         {...{
           ...this.props,
           publicPassPhrase,
+          privatePassPhrase,
           hasAttemptedOpen,
           onSetPublicPassPhrase,
+          onSetPrivatePassPhrase,
           onOpenWallet,
           onKeyDown
         }}
@@ -86,12 +90,17 @@ class OpenWalletBody extends React.Component {
     this.setState({ publicPassPhrase });
   }
 
-  onOpenWallet() {
-    if (!this.state.publicPassPhrase) {
-      return this.setState({ hasAttemptedOpen: true });
-    }
+  onSetPrivatePassPhrase(privatePassPhrase) {
+    this.setState({ privatePassPhrase });
+  }
 
-    this.props.onOpenWallet(this.state.publicPassPhrase, true);
+  onOpenWallet() {
+    /// TODO: determine if this can be removed or needs to stay?
+    // if (!this.state.publicPassPhrase) {
+    //   return this.setState({ hasAttemptedOpen: true });
+    // }
+
+    this.props.onOpenWallet(this.state.publicPassPhrase, this.state.privatePassPhrase, true);
     this.resetState();
   }
 

--- a/app/components/views/GetStartedPage/Page.js
+++ b/app/components/views/GetStartedPage/Page.js
@@ -3,12 +3,20 @@ import "style/GetStarted.less";
 import "style/Layout.less";
 
 const Page = ({ Header, Body, ...props }) => {
+
+  const hideLogo = props.startupError
+    || props.isOpenWalletPublicInputRequest
+    || props.isOpenWalletPrivateInputRequest
+    || props.isInputRequest
+    || props.showSettings
+    || props.showLogs;
+
   return (
     <div className="page-view inverted-colors">
       <Header {...props} />
       <div className="page-content-fixed">
         <DecredLoading
-          hidden={props.startupError || props.isInputRequest || props.showSettings || props.showLogs}
+          hidden={hideLogo}
           className="get-started-loading"
         />
         <Body {...props} />

--- a/app/connectors/walletStartup.js
+++ b/app/connectors/walletStartup.js
@@ -8,6 +8,8 @@ import * as da from "../actions/DaemonActions";
 const mapStateToProps = selectorMap({
   startStepIndex: sel.startStepIndex,
   isInputRequest: sel.isInputRequest,
+  isOpenWalletPublicInputRequest: sel.isOpenWalletPublicInputRequest,
+  isOpenWalletPrivateInputRequest: sel.isOpenWalletPrivateInputRequest,
   startupError: sel.startupError,
   confirmNewSeed: sel.confirmNewSeed,
   hasExistingWallet: sel.hasExistingWallet,

--- a/app/reducers/walletLoader.js
+++ b/app/reducers/walletLoader.js
@@ -2,7 +2,9 @@ import {
   CREATEWALLET_ATTEMPT, CREATEWALLET_FAILED, CREATEWALLET_SUCCESS,
   LOADER_ATTEMPT, LOADER_FAILED, LOADER_SUCCESS,
   WALLETEXIST_ATTEMPT, WALLETEXIST_FAILED, WALLETEXIST_SUCCESS,
-  OPENWALLET_INPUT, OPENWALLET_FAILED_INPUT, OPENWALLET_ATTEMPT, OPENWALLET_FAILED, OPENWALLET_SUCCESS,
+  OPENWALLET_PUBLIC_INPUT, OPENWALLET_FAILED_PUBLIC_INPUT,
+  OPENWALLET_PRIVATE_INPUT, OPENWALLET_FAILED_PRIVATE_INPUT,
+  OPENWALLET_ATTEMPT, OPENWALLET_FAILED, OPENWALLET_SUCCESS,
   CLOSEWALLET_ATTEMPT, CLOSEWALLET_FAILED, CLOSEWALLET_SUCCESS,
   STARTRPC_ATTEMPT, STARTRPC_FAILED, STARTRPC_SUCCESS, STARTRPC_RETRY,
   DISCOVERADDRESS_INPUT, DISCOVERADDRESS_FAILED_INPUT, DISCOVERADDRESS_ATTEMPT, DISCOVERADDRESS_FAILED, DISCOVERADDRESS_SUCCESS,
@@ -95,19 +97,29 @@ export default function walletLoader(state = {}, action) {
       advancedDaemonInputRequest: true,
       stepIndex: 3,
     };
-  case OPENWALLET_INPUT:
+  case OPENWALLET_PUBLIC_INPUT:
     return {...state,
-      openWalletInputRequest: true,
+      openWalletPublicInputRequest: true,
     };
-  case OPENWALLET_FAILED_INPUT:
+  case OPENWALLET_FAILED_PUBLIC_INPUT:
     return {...state,
       walletOpenError: String(action.error),
-      openWalletInputRequest: true,
+      openWalletPublicInputRequest: true,
+    };
+  case OPENWALLET_PRIVATE_INPUT:
+    return {...state,
+      openWalletPrivateInputRequest: true,
+    };
+  case OPENWALLET_FAILED_PRIVATE_INPUT:
+    return {...state,
+      walletOpenError: String(action.error),
+      openWalletPrivateInputRequest: true,
     };
   case OPENWALLET_ATTEMPT:
     return {...state,
       walletOpenError: false,
-      openWalletInputRequest: false,
+      openWalletPublicInputRequest: false,
+      openWalletPrivateInputRequest: false,
       walletOpenRequestAttempt: true,
     };
   case OPENWALLET_FAILED:

--- a/app/selectors.js
+++ b/app/selectors.js
@@ -86,7 +86,6 @@ export const availableWalletsSelect = createSelector(
 export const previousWallet = get(["daemon", "previousWallet"]);
 export const getWalletName = get(["daemon", "walletName"]);
 
-const openWalletInputRequest = get(["walletLoader", "openWalletInputRequest"]);
 const createWalletInputRequest = get(["walletLoader", "createWalletInputRequest"]);
 const discoverAddressInputRequest = get(["walletLoader", "discoverAddressInputRequest"]);
 const advancedDaemonInputRequest = get(["walletLoader", "advancedDaemonInputRequest"]);
@@ -94,12 +93,14 @@ const openWalletRequestAttempt = get(["walletLoader", "walletOpenRequestAttempt"
 const selectCreateWalletInputRequest = get(["daemon", "selectCreateWalletInputRequest"]);
 
 export const isInputRequest = or(
-  and(openWalletInputRequest, not(openWalletRequestAttempt)),
   createWalletInputRequest,
   discoverAddressInputRequest,
   and(openForm, isAdvancedDaemon, advancedDaemonInputRequest),
   selectCreateWalletInputRequest
 );
+
+export const isOpenWalletPublicInputRequest = get(["walletLoader", "openWalletPublicInputRequest"]);
+export const isOpenWalletPrivateInputRequest = get(["walletLoader", "openWalletPrivateInputRequest"]);
 
 export const balances = or(get(["grpc", "balances"]), () => []);
 export const walletService = get(["grpc", "walletService"]);

--- a/app/wallet/loader.js
+++ b/app/wallet/loader.js
@@ -33,11 +33,13 @@ export const createWallet = log((loader, pubPass, privPass, seed) =>
     loader.createWallet(request, error => error ? reject(error) : resolve());
   }), "Create Wallet", logOptionNoArgs());
 
-export const openWallet = log((loader, pubPass) =>
+export const openWallet = log((loader, pubPass, privPass) =>
   new Promise((resolve, reject) => {
     const request = new OpenWalletRequest();
     request.setPublicPassphrase(new Uint8Array(Buffer.from(pubPass)));
-    request.setPrivatePassphrase(new Uint8Array(Buffer.from("testnet123")));
+    if (privPass && privPass.length > 0) {
+      request.setPrivatePassphrase(new Uint8Array(Buffer.from(privPass)));
+    }
     loader.openWallet(request, error => error ? reject(error) : resolve());
   }), "Open Wallet", logOptionNoArgs());
 


### PR DESCRIPTION
After the user selects the wallet, the app will start
the wallet process, check the selected wallet exists,
and then attempts to open the wallet. To keep the private
passphrase from used in redux, use the state manager
to show the view and pass the entered value to the
rpc call.

Since the PUBLIC PASSPHRASE check already exists, the
PRIVATE PASSPHRASE request will mimic the same setup.

- Split store property OPENWALLET_INPUT into PRIVATE/PUBLIC.
- Replace isInputRequest with differentiator between priv/pub.
- Add private passphrase view to OpenWallet/DecryptForm.